### PR TITLE
Universal WEBP Image Component

### DIFF
--- a/src/components/modules/universal-img.vue
+++ b/src/components/modules/universal-img.vue
@@ -1,0 +1,48 @@
+<template>
+    <picture>
+      <source v-if="webpEnabled && !gif" media="screen" :srcset="loadImage(source) + '.webp'" type="image/webp">
+      <source v-if="!gif" media="screen" :srcset="loadImage(source)" type="image/png">
+      <img :alt="a11y" :src="loadImage(source)">
+    </picture>
+</template>
+
+<script>
+// [ Universal Image Component ] -------
+// This component was created to give developers
+// an easy way to use next-gen image formats with
+// appropriate fallbacks for old browsers.
+//
+// This component uses the <picture> element to house 3
+// different sources. WebP, Jpg and PNG. This component
+// takes advantage of Webpack to generate the Webp images.
+// All you need to supply to the component is the path to the
+// png supplied by the designer and the Accessibility Text.
+//
+// Because WebPACK needs to generate webP on runtime it takes
+// too long to compile for general dev practices. Therefore,
+// the WebP generation only works on production/staging.
+//
+// To mitigate issues each time the component is mounted it checks for
+// environment and disables webp when in dev mode.
+
+export default{
+  name: 'UniversalImage',
+
+  props: [ 'source', 'a11y', 'gif' ],
+
+  // Before mount check environment
+  beforeMount () {
+    // If environment is dev, disable webp.
+    if ( process.env.NODE_ENV === 'development' ) {
+      this.webpEnabled = false;
+    }
+  },
+
+  data: function(){
+    return{
+      // WebP Enabled by default
+      webpEnabled: true
+    };
+  },
+};
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -263,6 +263,12 @@ Vue.mixin({
 })
 
 
+// Global Component Registration
+// Centralizes components to ease on loading
+import UniversalImage     from '../src/components/modules/universal-img.vue';
+
+// Global Component Assign
+Vue.component('universal-image', UniversalImage);
 
 // [ Main Vue Instance ] ----------------------------
 const _vue = new Vue({

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,16 +5,24 @@
 // ----------------------------------------
 
 // Required Imports
+const webpack = require('webpack')
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 // Dev Server Configuration
 module.exports = merge(common, {
- mode: 'development',
- devtool: 'inline-source-map',
- devServer: {
+  mode: 'development',
+  devtool: 'inline-source-map',
+  devServer: {
      historyApiFallback: true,
      noInfo: true,
      contentBase: './dist'
-   }
+  },
+
+  plugins: [
+    // Set environment to Development
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('development')
+    }),
+  ]
 });


### PR DESCRIPTION
## Changes:
- Added a global component called `<universal-image>' to load webp images
- Added `development` as a NODE_ENV
- Added ability to toggle webp images to save processing during dev

## How To Test:
- In terminal: `npm run dev`
- Navigate to : `localhost:8080/`

Note: Port may differ based on simultaneous environments.

:beer:
