### PR TITLE
Cache Busting for Images

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -110,7 +110,7 @@ module.exports = {
       // Image Processing
       {
         test: /\.(png|jpg|jpeg|gif|svg)$/,
-        loaders: [ 'file-loader?context=src/assets/images&name=assets/images/[path][name].[ext]', {
+        loaders: [ 'file-loader?context=src/assets/images&name=assets/images/[path][hash].[ext]', {
           loader: 'image-webpack-loader',
           query: {
             // JPEG Processing


### PR DESCRIPTION
## Changes:
- Updated webpack to replace image name with hash

## How To Test:
- In terminal: `npm run dev`
- Navigate to : `localhost:8080/`

Note: Port may differ based on simultaneous environments.

N/A

:beer:
